### PR TITLE
Fix state=list in ceph_pool module

### DIFF
--- a/plugins/modules/ceph_pool.py
+++ b/plugins/modules/ceph_pool.py
@@ -46,8 +46,9 @@ options:
     name:
         description:
             - name of the Ceph pool
+            - Required if I(state) is C(present) or C(present)
         type: str
-        required: true
+        required: false
     state:
         description:
             - If 'present' is used, the module creates a pool if it doesn't exist or update it if it already exists.
@@ -528,9 +529,9 @@ def update_pool(module, cluster, name,
 def run_module():
     module_args = dict(
         cluster=dict(type='str', required=False, default='ceph'),
-        name=dict(type='str', required=True),
+        name=dict(type='str', required=False),
         state=dict(type='str', required=False, default='present',
-                   choices=['present', 'absent']),
+                   choices=['present', 'absent', 'list']),
         details=dict(type='bool', required=False, default=False),
         size=dict(type='str', required=False, default='3'),
         min_size=dict(type='str', required=False),
@@ -563,6 +564,9 @@ def run_module():
     pg_autoscale_mode = module.params.get('pg_autoscale_mode')
     target_size_ratio = module.params.get('target_size_ratio')
     application = module.params.get('application')
+
+    if state != "list" and not name:
+        module.fail_json("state change requires a pool name")
 
     if (module.params.get('pg_autoscale_mode').lower() in
             ['true', 'on', 'yes']):
@@ -679,7 +683,7 @@ def run_module():
     elif state == "list":
         rc, cmd, out, err = exec_command(module,
                                          list_pools(cluster,
-                                                    name, user,
+                                                    user,
                                                     user_key,
                                                     details,
                                                     container_image=container_image))  # noqa: E501


### PR DESCRIPTION
This PR fixes `list` not being allowed by the `ceph_pool` module, despite being implemented.

I've also fixed a crash caused by an extra parameter being passed.

> Traceback (most recent call last):
  File "<stdin>", line 107, in <module>
  File "<stdin>", line 99, in _ansiballz_main
  File "<stdin>", line 47, in invoke_module
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/ansible_ceph.automation.ceph_pool_payload_9wlbrefz/ansible_ceph.automation.ceph_pool_payload.zip/ansible_collections/ceph/automation/plugins/modules/ceph_pool.py", line 718, in <module>
  File "/tmp/ansible_ceph.automation.ceph_pool_payload_9wlbrefz/ansible_ceph.automation.ceph_pool_payload.zip/ansible_collections/ceph/automation/plugins/modules/ceph_pool.py", line 714, in main
  File "/tmp/ansible_ceph.automation.ceph_pool_payload_9wlbrefz/ansible_ceph.automation.ceph_pool_payload.zip/ansible_collections/ceph/automation/plugins/modules/ceph_pool.py", line 693, in run_module
  File "/tmp/ansible_ceph.automation.ceph_pool_payload_9wlbrefz/ansible_ceph.automation.ceph_pool_payload.zip/ansible_collections/ceph/automation/plugins/module_utils/ceph_common.py", line 102, in exec_command
  File "/tmp/ansible_ceph.automation.ceph_pool_payload_9wlbrefz/ansible_ceph.automation.ceph_pool_payload.zip/ansible/module_utils/basic.py", line 1860, in run_command
  File "/tmp/ansible_ceph.automation.ceph_pool_payload_9wlbrefz/ansible_ceph.automation.ceph_pool_payload.zip/ansible/module_utils/basic.py", line 1860, in <listcomp>
  File "<frozen posixpath>", line 296, in expandvars
TypeError: expected str, bytes or os.PathLike object, not bool

The `name` parameter isn't required for `list` (neither is it being used), so only make it required if state is not `list`.