### PR TITLE
fix ceph_orch_apply multiple yaml

### DIFF
--- a/changelogs/fragments/ceph_orch_apply.yaml
+++ b/changelogs/fragments/ceph_orch_apply.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - ceph_orch_apply - The fix ensures that the existing orchestrator service is loaded when  
-    there are multiple YAML documents returning data for the same service.  
+  - ceph_orch_apply - The fix ensures that the existing orchestrator service is loaded when
+    there are multiple YAML documents returning data for the same service.

--- a/changelogs/fragments/ceph_orch_apply.yaml
+++ b/changelogs/fragments/ceph_orch_apply.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ceph_orch_apply - The fix ensures that the existing orchestrator service is loaded when  
+    there are multiple YAML documents returning data for the same service.  

--- a/plugins/modules/ceph_orch_apply.py
+++ b/plugins/modules/ceph_orch_apply.py
@@ -111,7 +111,7 @@ def retrieve_current_spec(module: AnsibleModule, expected_spec: Dict) -> Dict:
         # if there is no existing service, cephadm returns the string 'No services reported'
         return {}
     else:
-        return yaml.safe_load(out[1])
+        return yaml.safe_load_all(out[1])
 
 
 def apply_spec(module: "AnsibleModule",

--- a/plugins/modules/ceph_orch_apply.py
+++ b/plugins/modules/ceph_orch_apply.py
@@ -32,7 +32,11 @@ module: ceph_orch_apply
 short_description: apply service spec
 version_added: "1.0.0"
 description:
-    - apply a service spec
+    - Manage and apply service specifications.
+    - This module is designed to apply a single service specification per execution.
+    - Multiple service specifications can be applied by using a loop.
+    - If any default key in the service specification is missing, the module will indicate a changed status.
+    - To prevent unnecessary changes, ensure all keys with their default values are included in the service specification.
 options:
     fsid:
         description:
@@ -60,16 +64,28 @@ author:
 '''
 
 EXAMPLES = '''
-- name: apply osd spec
-  ceph_orch_apply:
-    spec: |
-      service_type: osd
-      service_id: osd
+- name: apply cluster spec
+  ceph.automation.ceph_orch_apply:
+    spec: "{{ item }}"
+  loop:
+    - service_type: "nfs"
+      service_id: "iac"
       placement:
-        label: osds
+        count: 1
+        label: "nfs"
       spec:
-        data_devices:
-          all: true
+        port: 5001
+    - service_type: "ingress"
+      service_id: "nfs.iac"
+      placement:
+        count: 1
+        label: "nfs"
+      spec:
+        backend_service: "nfs.iac"
+        first_virtual_router_id: 51
+        frontend_port: 2049
+        monitor_port: 9001
+        virtual_ip: "172.16.20.11/24"
 '''
 
 RETURN = '''#  '''

--- a/plugins/modules/ceph_orch_apply.py
+++ b/plugins/modules/ceph_orch_apply.py
@@ -120,10 +120,7 @@ def parse_spec(spec: str) -> Dict:
 def retrieve_current_spec(module: AnsibleModule, expected_spec: Dict) -> Dict:
     """ retrieve current config of the service """
     service: str = expected_spec["service_type"]
-    if "service_name" not in expected_spec.keys():
-        srv_name: str = "%s.%s" % (expected_spec["service_type"], expected_spec["service_id"])
-    else:
-         srv_name: str = expected_spec["service_name"]
+    srv_name: str = "%s.%s" % (expected_spec["service_type"], expected_spec["service_id"])
     cmd = build_base_cmd_orch(module)
     cmd.extend(['ls', service, srv_name, '--format=yaml'])
     out = module.run_command(cmd)

--- a/plugins/modules/ceph_orch_apply.py
+++ b/plugins/modules/ceph_orch_apply.py
@@ -104,14 +104,18 @@ def parse_spec(spec: str) -> Dict:
 def retrieve_current_spec(module: AnsibleModule, expected_spec: Dict) -> Dict:
     """ retrieve current config of the service """
     service: str = expected_spec["service_type"]
+    if "service_name" not in expected_spec.keys():
+        srv_name: str = "%s.%s" % (expected_spec["service_type"], expected_spec["service_id"])
+    else:
+         srv_name: str = expected_spec["service_name"]
     cmd = build_base_cmd_orch(module)
-    cmd.extend(['ls', service, '--format=yaml'])
+    cmd.extend(['ls', service, srv_name, '--format=yaml'])
     out = module.run_command(cmd)
     if isinstance(out, str):
         # if there is no existing service, cephadm returns the string 'No services reported'
         return {}
     else:
-        return yaml.safe_load_all(out[1])
+        return yaml.safe_load(out[1])
 
 
 def apply_spec(module: "AnsibleModule",


### PR DESCRIPTION
this fix will load existing orch service when we have more than one yaml return for same service.

Current yaml.safe_load return exception when we have more than 1 yaml  output exist   via 
```
ceph orch ls {SERVICE} --format=yaml
```
 This is expected behavior of   yaml.safe_load however we should expet more than 1 yaml "document" for example 

```
ceph1:~ # ceph orch ls ingress --format=yaml
service_type: ingress
service_id: nfs.iac
service_name: ingress.nfs.iac
placement:
  count: 1
  label: nfs
spec:
  backend_service: nfs.iac
  first_virtual_router_id: 50
  frontend_port: 2049
  monitor_port: 9001
  virtual_ip: 172.16.20.11/24
status:
  created: '2025-01-21T17:57:52.630212Z'
  last_refresh: '2025-01-21T17:53:42.051637Z'
  ports:
  - 2049
  - 9001
  running: 2
  size: 2
  virtual_ip: 172.16.20.11/24
events:
- 2025-01-21T17:57:54.044109Z service:ingress.nfs.iac [INFO] "service was created"
---
service_type: ingress
service_id: rgw.iac
service_name: ingress.rgw.iac
placement:
  count: 1
  label: rgw
spec:
  backend_service: rgw.iac
  first_virtual_router_id: 50
  frontend_port: 8080
  monitor_port: 9002
  virtual_ip: 172.16.20.12/24
status:
  created: '2025-01-21T09:06:37.514928Z'
  last_refresh: '2025-01-21T17:57:50.437677Z'
  ports:
  - 8080
  - 9002
  running: 2
  size: 2
  virtual_ip: 172.16.20.12/24
events:
- 2025-01-21T09:06:53.351531Z service:ingress.rgw.iac [INFO] "service was created"

```

To handle that we should use  **yaml.safe_load_all** 

This is a simple fix , this is my first time with ceph.automation , from what I see this module is ceph/cephadm **"on steroids :) "** so no surprises , my point is ... I hope I not miss something please double check 

Regards,