### PR TITLE
set pg_num when autoscale_mode=warn

### DIFF
--- a/plugins/modules/ceph_pool.py
+++ b/plugins/modules/ceph_pool.py
@@ -425,7 +425,7 @@ def create_pool(cluster,
     args = ['create', user_pool_config['pool_name']['value'],
             user_pool_config['type']['value']]
 
-    if user_pool_config['pg_autoscale_mode']['value'] == 'off':
+    if user_pool_config['pg_autoscale_mode']['value'] in ["off","warn"]:
         args.extend(['--pg_num',
                      user_pool_config['pg_num']['value'],
                      '--pgp_num',


### PR DESCRIPTION
This PR adds "warn" mode as a valid state setting the `pg_num`/etc on pool creation.

`ceph_pool` will only set the `pg_num` and `pgp_num` options when the auto_scaler is set to off. While it makes sense not to set them when the auto_scaler is on, the auto_scaler can also be set to "warn" mode where it will not adjust the PG count either. It seems counterintuitive to not allow configuring pg count in that case.
