### PR TITLE
github actions: Fix access rights

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   release_automation_hub:
-    uses: ansible/ansible-content-actions/.github/workflows/release_galaxy.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/release_galaxy.yaml@551b3e26e5adb0bec13bf0de0983f98e0fa5a7f8
     with:
       environment: release
     secrets:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,18 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   changelog:
-    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@551b3e26e5adb0bec13bf0de0983f98e0fa5a7f8
     if: github.event_name == 'pull_request'
   build-import:
-    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@551b3e26e5adb0bec13bf0de0983f98e0fa5a7f8
   ansible-lint:
-    uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@551b3e26e5adb0bec13bf0de0983f98e0fa5a7f8
   sanity:
-    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@551b3e26e5adb0bec13bf0de0983f98e0fa5a7f8
   unit-galaxy:
-    uses: ansible/ansible-content-actions/.github/workflows/unit.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/unit.yaml@551b3e26e5adb0bec13bf0de0983f98e0fa5a7f8
   unit-source:
-    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@main
+    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@551b3e26e5adb0bec13bf0de0983f98e0fa5a7f
     with:
       collection_pre_install: >-
         git+https://github.com/ansible-collections/ansible.utils.git


### PR DESCRIPTION
For security reasons[1] only pinned actions to sha1 are allowed. Current sha1: 551b3e26e5adb0bec13bf0de0983f98e0fa5a7f8

[1] https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066