### PR TITLE
orchestrator: Add use_cephadm toggle for native ceph vs cephadm shell…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,68 @@ ansible-galaxy collection install ceph.automation:==X.Y.Z
 
 See [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html) for more details.
 
+## Ceph CLI execution (cephadm vs host `ceph`)
+
+Several modules run Ceph commands either through **cephadm** (`cephadm shell ceph …`) or directly with the **`ceph`** binary on the target (keyring auth). This matters for clusters **not** managed by cephadm (for example some Proxmox VE setups).
+
+### Options
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `use_cephadm` | `true` | `true`: cephadm shell; `false`: host `ceph` |
+| `cluster` | `ceph` | Cluster name for host `ceph` (`--cluster`) |
+| `ceph_client` | `client.admin` | Client name for host `ceph` (`-n`) |
+| `keyring` | *(derived)* | Keyring path; default `/etc/ceph/<cluster>.<ceph_client>.keyring` |
+
+These options are documented on each affected module and shared via the **`ceph.automation.ceph_cli`** doc fragment.
+
+### Apply to every supported module in a play
+
+Use the **`ceph_cli`** action group so you set `use_cephadm` once (see `meta/runtime.yml` for the module list):
+
+```yaml
+- name: Manage Ceph without cephadm shell
+  hosts: ceph_nodes
+  become: true
+
+  module_defaults:
+    group/ceph.automation.ceph_cli:
+      use_cephadm: false
+      # Optional if paths differ from defaults:
+      # cluster: ceph
+      # ceph_client: client.admin
+      # keyring: /etc/ceph/ceph.client.admin.keyring
+
+  tasks:
+    - name: Read a config value
+      ceph.automation.ceph_config:
+        action: get
+        who: global
+        option: osd_pool_default_size
+```
+
+### Override on a single task
+
+```yaml
+- hosts: mixed
+  become: true
+  module_defaults:
+    group/ceph.automation.ceph_cli:
+      use_cephadm: true
+
+  tasks:
+    - name: This task uses host ceph instead
+      ceph.automation.ceph_config:
+        use_cephadm: false
+        action: get
+        who: global
+        option: osd_pool_default_size
+```
+
+### `cephadm_registry_login`
+
+`cephadm_registry_login` only works with cephadm. It fails if `use_cephadm: false`.
+
 ## Release notes
 
 See the [changelog](https://github.com/ceph/ceph.automation/blob/main/CHANGELOG.rst).

--- a/changelogs/fragments/use-cephadm-native-cli.yml
+++ b/changelogs/fragments/use-cephadm-native-cli.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - >-
+    Add ``use_cephadm`` (default ``true``) and ``cluster``, ``ceph_client``, ``keyring`` for
+    running Ceph commands through ``cephadm shell`` or the host ``ceph`` binary; register the
+    ``ceph_cli`` action group for ``module_defaults``; add the ``ceph.automation.ceph_cli`` doc
+    fragment; document usage in the README
+    (https://github.com/ceph/ceph.automation/pull/40).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,12 @@
 ---
 requires_ansible: ">=2.15.0"
+action_groups:
+  ceph_cli:
+    - ceph_config
+    - ceph_crush_rule
+    - ceph_crush_rule_info
+    - ceph_fs_volume
+    - ceph_orch_apply
+    - ceph_orch_daemon
+    - ceph_orch_host
+    - cephadm_registry_login

--- a/plugins/doc_fragments/ceph_cli.py
+++ b/plugins/doc_fragments/ceph_cli.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+options:
+  use_cephadm:
+    description:
+      - When true (default), run the Ceph CLI through Cephadm shell (``cephadm shell ceph ...``).
+      - When false, run the ``ceph`` binary on the target host with keyring authentication
+        (for example Proxmox or other non-Cephadm clusters).
+      - May be set for all modules in ``group/ceph.automation.ceph_cli`` via ``module_defaults``.
+    type: bool
+    default: true
+    version_added: '1.2.0'
+  cluster:
+    description:
+      - Ceph cluster name used with the native ``ceph`` CLI when ``use_cephadm`` is false.
+    type: str
+    default: ceph
+    version_added: '1.2.0'
+  ceph_client:
+    description:
+      - Ceph client name (``-n``) for the native ``ceph`` CLI when ``use_cephadm`` is false.
+    type: str
+    default: client.admin
+    version_added: '1.2.0'
+  keyring:
+    description:
+      - Path to the keyring file for the native ``ceph`` CLI when ``use_cephadm`` is false.
+      - Defaults to ``/etc/ceph/<cluster>.<ceph_client>.keyring``.
+    type: str
+    required: false
+    version_added: '1.2.0'
+'''

--- a/plugins/module_utils/ceph_common.py
+++ b/plugins/module_utils/ceph_common.py
@@ -6,6 +6,13 @@ import os
 import time
 from typing import TYPE_CHECKING, Any, List, Dict, Callable, Type, TypeVar, Optional
 
+CEPH_CLI_SHARED_OPTIONS = dict(
+    use_cephadm=dict(type='bool', required=False, default=True),
+    cluster=dict(type='str', required=False, default='ceph'),
+    ceph_client=dict(type='str', required=False, default='client.admin'),
+    keyring=dict(type='str', required=False, default=None, no_log=True),
+)
+
 if TYPE_CHECKING:
     from ansible.module_utils.basic import AnsibleModule  # type: ignore
 
@@ -121,7 +128,54 @@ def retry(exceptions: Type[ExceptionType], module: "AnsibleModule", retries: int
     return decorator
 
 
+def module_use_cephadm(module: "AnsibleModule") -> bool:
+    '''
+    Resolve whether to run Ceph through cephadm shell or the host ceph binary (default true).
+    '''
+    params = getattr(module, 'params', None) or {}
+    return bool(params.get('use_cephadm', True))
+
+
+def build_native_ceph_prefix(module: "AnsibleModule") -> List[str]:
+    '''
+    Build ceph with cluster authentication for non-Cephadm hosts.
+    '''
+    cluster = module.params.get('cluster') or 'ceph'
+    ceph_client = module.params.get('ceph_client') or 'client.admin'
+    keyring = module.params.get('keyring')
+    if not keyring:
+        keyring = '/etc/ceph/{}.{}.keyring'.format(cluster, ceph_client)
+    return ['ceph', '-n', ceph_client, '-k', keyring, '--cluster', cluster]
+
+
+def append_shell_ceph_subargs(module: "AnsibleModule", cmd: List[str], argv: List[str]) -> None:
+    '''
+    Append arguments to ceph in cephadm shell ceph ...,
+    or follow the host ceph when use_cephadm is false.
+
+    :param argv: e.g. ['config', 'set', 'mon', 'foo', 'bar'] without a leading ceph.
+    '''
+    if module_use_cephadm(module):
+        cmd.extend(['ceph'] + argv)
+    else:
+        cmd.extend(argv)
+
+
+def append_cephadm_shell_tmpdir_mount(module: "AnsibleModule", cmd: List[str], tmpdirname: str) -> None:
+    '''
+    Append cephadm shell --mount options so a host temp directory is visible in the container.
+    No-op when use_cephadm is false.
+    '''
+    if not module_use_cephadm(module):
+        return
+    cmd.extend(['--mount', '{0}:{0}'.format(tmpdirname), '--'])
+
+
 def build_base_cmd(module: "AnsibleModule") -> List[str]:
+    if not module_use_cephadm(module):
+        module.fail_json(
+            msg='This module only supports Cephadm. Set use_cephadm to true or use a different module.'
+        )
     cmd = ['cephadm']
     docker = module.params.get('docker')
     image = module.params.get('image')
@@ -135,21 +189,22 @@ def build_base_cmd(module: "AnsibleModule") -> List[str]:
 
 
 def build_base_cmd_shell(module: "AnsibleModule") -> List[str]:
-    cmd = build_base_cmd(module)
-    fsid = module.params.get('fsid')
+    if module_use_cephadm(module):
+        cmd = build_base_cmd(module)
+        fsid = module.params.get('fsid')
 
-    cmd.append('shell')
+        cmd.append('shell')
 
-    if fsid:
-        cmd.extend(['--fsid', fsid])
+        if fsid:
+            cmd.extend(['--fsid', fsid])
 
-    return cmd
+        return cmd
+    return build_native_ceph_prefix(module)
 
 
 def build_base_cmd_orch(module: "AnsibleModule") -> List[str]:
     cmd = build_base_cmd_shell(module)
-    cmd.extend(['ceph', 'orch'])
-
+    append_shell_ceph_subargs(module, cmd, ['orch'])
     return cmd
 
 

--- a/plugins/module_utils/ceph_fs_volume_common.py
+++ b/plugins/module_utils/ceph_fs_volume_common.py
@@ -6,9 +6,9 @@ from ansible.module_utils.basic import AnsibleModule
 
 try:
     from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import \
-        exec_command, build_base_cmd_shell
+        exec_command, build_base_cmd_shell, append_shell_ceph_subargs
 except ImportError:
-    from module_utils.ceph_common import exec_command, build_base_cmd_shell
+    from module_utils.ceph_common import exec_command, build_base_cmd_shell, append_shell_ceph_subargs
 
 from typing import List, Tuple, Union
 
@@ -30,7 +30,7 @@ def list_fs_volumes(
     """
 
     list_fs = build_base_cmd_shell(module)
-    list_fs.extend(['ceph', 'fs'])
+    append_shell_ceph_subargs(module, list_fs, ['fs'])
 
     if volume_type == 'volume':
         list_fs.extend(['volume', 'ls', '--format=json'])
@@ -61,7 +61,7 @@ def get_fs_volume(
     """
 
     get_fs = build_base_cmd_shell(module)
-    get_fs.extend(['ceph', 'fs'])
+    append_shell_ceph_subargs(module, get_fs, ['fs'])
 
     if volume_type == 'volume':
         get_fs.extend(['volume', 'info', name, '--format=json'])

--- a/plugins/modules/ceph_config.py
+++ b/plugins/modules/ceph_config.py
@@ -21,6 +21,8 @@ short_description: set ceph config
 version_added: "1.1.0"
 description:
     - Set Ceph config options.
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
 options:
     fsid:
         description:
@@ -87,9 +89,21 @@ RETURN = '''#  '''
 from typing import Any, Dict, List, Tuple, Union
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
+    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import (  # type: ignore
+        exit_module,
+        build_base_cmd_shell,
+        fatal,
+        append_shell_ceph_subargs,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 except ImportError:
-    from module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
+    from module_utils.ceph_common import (  # type: ignore
+        exit_module,
+        build_base_cmd_shell,
+        fatal,
+        append_shell_ceph_subargs,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 
 import datetime
 import json
@@ -100,7 +114,7 @@ def set_option(module: "AnsibleModule",
                option: str,
                value: str) -> Tuple[int, List[str], str, str]:
     cmd = build_base_cmd_shell(module)
-    cmd.extend(['ceph', 'config', 'set', who, option, value])
+    append_shell_ceph_subargs(module, cmd, ['config', 'set', who, option, value])
 
     rc, out, err = module.run_command(cmd)
 
@@ -109,7 +123,7 @@ def set_option(module: "AnsibleModule",
 
 def get_config_dump(module: "AnsibleModule") -> Tuple[int, List[str], str, str]:
     cmd = build_base_cmd_shell(module)
-    cmd.extend(['ceph', 'config', 'dump', '--format', 'json'])
+    append_shell_ceph_subargs(module, cmd, ['config', 'dump', '--format', 'json'])
     rc, out, err = module.run_command(cmd)
     if rc:
         fatal(message=f"Can't get current configuration via `ceph config dump`.Error:\n{err}", module=module)
@@ -127,6 +141,7 @@ def get_current_value(who: str, option: str, config_dump: List[Dict[str, Any]]) 
 def main() -> None:
     module = AnsibleModule(
         argument_spec=dict(
+            **CEPH_CLI_SHARED_OPTIONS,
             who=dict(type='str', required=True),
             action=dict(type='str', required=False, choices=['get', 'set'], default='set'),
             option=dict(type='str', required=True),

--- a/plugins/modules/ceph_crush_rule.py
+++ b/plugins/modules/ceph_crush_rule.py
@@ -32,6 +32,8 @@ version_added: "1.1.0"
 description:
     - Manage Ceph Crush rule(s) creation, deletion and updates.
     - Erasure-coded rules cannot be updated at the time.
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
 options:
     name:
         description:
@@ -126,12 +128,20 @@ try:
     from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import \
         exit_module, \
         build_base_cmd_shell, \
-        exec_command
+        exec_command, \
+        append_shell_ceph_subargs, \
+        append_cephadm_shell_tmpdir_mount, \
+        module_use_cephadm, \
+        CEPH_CLI_SHARED_OPTIONS
 except ImportError:
     from module_utils.ceph_common import \
         exit_module, \
         build_base_cmd_shell, \
-        exec_command
+        exec_command, \
+        append_shell_ceph_subargs, \
+        append_cephadm_shell_tmpdir_mount, \
+        module_use_cephadm, \
+        CEPH_CLI_SHARED_OPTIONS
 
 from typing import Dict, List, Tuple
 import datetime
@@ -162,7 +172,7 @@ def create_rule(module: AnsibleModule) -> List[str]:
     profile = module.params.get('profile')
 
     cmd = build_base_cmd_shell(module)
-    cmd.extend(['ceph', 'osd', 'crush', 'rule'])
+    append_shell_ceph_subargs(module, cmd, ['osd', 'crush', 'rule'])
 
     if rule_type == 'replicated':
         cmd.extend(['create-replicated', name, bucket_root, bucket_type])
@@ -187,7 +197,7 @@ def remove_rule(module: AnsibleModule) -> List[str]:
     name = module.params.get('name')
 
     cmd = build_base_cmd_shell(module)
-    cmd.extend(['ceph', 'osd', 'crush', 'rule', 'rm', name])
+    append_shell_ceph_subargs(module, cmd, ['osd', 'crush', 'rule', 'rm', name])
 
     return cmd
 
@@ -234,17 +244,20 @@ def decompile_crushmap(module: AnsibleModule) -> Tuple[int, List[str], str, str]
         decompiled_map = os.path.join(tmpdirname, '_crushmap.txt')
 
         cmd = build_base_cmd_shell(module)
-        cmd.extend(['--mount', '{0}:{0}'.format(tmpdirname), '--'])
+        append_cephadm_shell_tmpdir_mount(module, cmd, tmpdirname)
 
         dump_crush_map = cmd.copy()
-        dump_crush_map.extend(['ceph', 'osd', 'getcrushmap', '-o', binary_map])
+        append_shell_ceph_subargs(module, dump_crush_map, ['osd', 'getcrushmap', '-o', binary_map])
 
         res = exec_command(module, dump_crush_map)
         if res[0] != 0:
             return res[0], res[1], 'dump of the CRUSH map failed with output: {}'.format(res[2]), res[3]
 
-        decompile_map = cmd.copy()
-        decompile_map.extend(['crushtool', '-d', binary_map, '-o', decompiled_map])
+        if module_use_cephadm(module):
+            decompile_map = cmd.copy()
+            decompile_map.extend(['crushtool', '-d', binary_map, '-o', decompiled_map])
+        else:
+            decompile_map = ['crushtool', '-d', binary_map, '-o', decompiled_map]
 
         res = exec_command(module, decompile_map)
         if res[0] != 0:
@@ -328,17 +341,20 @@ def install_crushmap(module: AnsibleModule, crushmap_content: str) -> Tuple[int,
             f.write(crushmap_content)
 
         cmd = build_base_cmd_shell(module)
-        cmd.extend(['--mount', '{0}:{0}'.format(tmpdirname), '--'])
+        append_cephadm_shell_tmpdir_mount(module, cmd, tmpdirname)
 
-        compile_map = cmd.copy()
-        compile_map.extend(['crushtool', '-c', patched_map, '-o', binary_map])
+        if module_use_cephadm(module):
+            compile_map = cmd.copy()
+            compile_map.extend(['crushtool', '-c', patched_map, '-o', binary_map])
+        else:
+            compile_map = ['crushtool', '-c', patched_map, '-o', binary_map]
 
         res = exec_command(module, compile_map)
         if res[0] != 0:
             return res[0], res[1], 'compilation of the CRUSH map failed with output: {}'.format(res[2]), res[3]
 
         install_map = cmd.copy()
-        install_map.extend(['ceph', 'osd', 'setcrushmap', '-i', binary_map])
+        append_shell_ceph_subargs(module, install_map, ['osd', 'setcrushmap', '-i', binary_map])
 
         res = exec_command(module, install_map)
         if res[0] != 0:
@@ -350,6 +366,7 @@ def install_crushmap(module: AnsibleModule, crushmap_content: str) -> Tuple[int,
 def main():
     module = AnsibleModule(
         argument_spec=dict(
+            **CEPH_CLI_SHARED_OPTIONS,
             name=dict(type='str', required=True),
             fsid=dict(type='str', required=False),
             image=dict(type='str', required=False),
@@ -395,7 +412,7 @@ def main():
     changed = False
 
     get_rule = build_base_cmd_shell(module)
-    get_rule.extend(['ceph', 'osd', 'crush', 'rule', 'dump', name, '--format=json'])
+    append_shell_ceph_subargs(module, get_rule, ['osd', 'crush', 'rule', 'dump', name, '--format=json'])
     rc, cmd, out, err = exec_command(module, get_rule)
 
     if state == "present":

--- a/plugins/modules/ceph_crush_rule_info.py
+++ b/plugins/modules/ceph_crush_rule_info.py
@@ -29,6 +29,8 @@ short_description: Lists Ceph Crush Replicated/Erasure Rules
 version_added: "1.1.0"
 description:
     - Retrieves Ceph Crush rule(s).
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
 options:
     name:
         description:
@@ -63,12 +65,16 @@ try:
     from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import \
         build_base_cmd_shell, \
         exit_module, \
-        exec_command
+        exec_command, \
+        append_shell_ceph_subargs, \
+        CEPH_CLI_SHARED_OPTIONS
 except ImportError:
     from module_utils.ceph_common import \
         build_base_cmd_shell, \
         exit_module, \
-        exec_command
+        exec_command, \
+        append_shell_ceph_subargs, \
+        CEPH_CLI_SHARED_OPTIONS
 
 import datetime
 
@@ -76,6 +82,7 @@ import datetime
 def main():
     module = AnsibleModule(
         argument_spec=dict(
+            **CEPH_CLI_SHARED_OPTIONS,
             name=dict(type='str', required=False),
             fsid=dict(type='str', required=False),
             image=dict(type='str', required=False),
@@ -87,7 +94,7 @@ def main():
 
     name = module.params.get('name')
     cmd = build_base_cmd_shell(module)
-    cmd.extend(['ceph', 'osd', 'crush', 'rule', 'dump', name, '--format=json'])
+    append_shell_ceph_subargs(module, cmd, ['osd', 'crush', 'rule', 'dump', name, '--format=json'])
     rc, cmd, out, err = exec_command(module, cmd)
 
     exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)  # noqa: E501

--- a/plugins/modules/ceph_crush_rule_info.py
+++ b/plugins/modules/ceph_crush_rule_info.py
@@ -94,7 +94,11 @@ def main():
 
     name = module.params.get('name')
     cmd = build_base_cmd_shell(module)
-    append_shell_ceph_subargs(module, cmd, ['osd', 'crush', 'rule', 'dump', name, '--format=json'])
+    subargs = ['osd', 'crush', 'rule', 'dump']
+    if name:
+        subargs.append(name)
+    subargs.append('--format=json')
+    append_shell_ceph_subargs(module, cmd, subargs)
     rc, cmd, out, err = exec_command(module, cmd)
 
     exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)  # noqa: E501

--- a/plugins/modules/ceph_fs_volume.py
+++ b/plugins/modules/ceph_fs_volume.py
@@ -35,6 +35,8 @@ description:
     - Module provides creation, deletion and updates of volumes, subvolume groups and subvolumes.
     - Not all methods (such as tree pinning) are supported at the time.
     - This module intended to work only with orchestrated Ceph deployments (Cephadm).
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
 options:
     fsid:
         description:
@@ -161,11 +163,17 @@ from ansible.module_utils.basic import AnsibleModule
 
 try:
     from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import \
-        exec_command, build_base_cmd_shell, exit_module
+        exec_command, build_base_cmd_shell, exit_module, append_shell_ceph_subargs, CEPH_CLI_SHARED_OPTIONS
     from ansible_collections.ceph.automation.plugins.module_utils.ceph_fs_volume_common import \
         get_fs_volume
 except ImportError:
-    from module_utils.ceph_common import exec_command, build_base_cmd_shell, exit_module
+    from module_utils.ceph_common import (
+        exec_command,
+        build_base_cmd_shell,
+        exit_module,
+        append_shell_ceph_subargs,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
     from module_utils.ceph_fs_volume_common import get_fs_volume
 
 import datetime
@@ -223,7 +231,7 @@ def resize_fs_volume(
     no_shrink = '--no-shrink' if not module.params['force_shrink'] else None
 
     resize_fs = build_base_cmd_shell(module)
-    resize_fs.extend(['ceph', 'fs'])
+    append_shell_ceph_subargs(module, resize_fs, ['fs'])
 
     if volume_type == 'subvolume_group':
         resize_fs.extend(['subvolumegroup', 'resize', parent_volume, name, size, no_shrink])
@@ -256,7 +264,7 @@ def create_fs_volume(
     """
 
     create_fs = build_base_cmd_shell(module)
-    create_fs.extend(['ceph', 'fs'])
+    append_shell_ceph_subargs(module, create_fs, ['fs'])
 
     if volume_type == 'volume':
         placement = module.params.get('initial_placement', None)
@@ -296,7 +304,8 @@ def get_remove_allowed_flag(module: AnsibleModule) -> bool:
 
     removal_allowed = False
     get_flag = build_base_cmd_shell(module)
-    get_flag.extend(['ceph', 'config', 'get', 'mon', 'mon_allow_pool_delete', '--format=json'])
+    append_shell_ceph_subargs(
+        module, get_flag, ['config', 'get', 'mon', 'mon_allow_pool_delete', '--format=json'])
     rc, cmd, out, err = exec_command(module, get_flag)
     if rc == 0:
         removal_allowed = json.loads(out)
@@ -317,7 +326,8 @@ def set_remove_allowed_flag(
     """
 
     set_flag = build_base_cmd_shell(module)
-    set_flag.extend(['ceph', 'config', 'set', 'mon', 'mon_allow_pool_delete', str(flag_value)])
+    append_shell_ceph_subargs(
+        module, set_flag, ['config', 'set', 'mon', 'mon_allow_pool_delete', str(flag_value)])
 
     return exec_command(module, set_flag)
 
@@ -344,7 +354,7 @@ def remove_fs_volume(
     removal_allowed = get_remove_allowed_flag(module)
 
     remove_volume = build_base_cmd_shell(module)
-    remove_volume.extend(['ceph', 'fs'])
+    append_shell_ceph_subargs(module, remove_volume, ['fs'])
 
     if volume_type == 'volume':
         remove_volume.extend(['volume', 'rm', name, '--yes-i-really-mean-it'])
@@ -374,6 +384,7 @@ def remove_fs_volume(
 def run_module():
     module = AnsibleModule(
         argument_spec=dict(
+            **CEPH_CLI_SHARED_OPTIONS,
             fsid=dict(type='str', required=False),
             image=dict(type='str', required=False),
             name=dict(type='str', required=True),

--- a/plugins/modules/ceph_orch_apply.py
+++ b/plugins/modules/ceph_orch_apply.py
@@ -37,6 +37,8 @@ description:
     - Multiple service specifications can be applied by using a loop.
     - If any default key in the service specification is missing, the module will indicate a changed status.
     - To prevent unnecessary changes, ensure all keys with their default values are included in the service specification.
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
 options:
     fsid:
         description:
@@ -106,9 +108,13 @@ import datetime
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
+    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import (  # type: ignore
+        exit_module,
+        build_base_cmd_orch,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 except ImportError:
-    from module_utils.ceph_common import exit_module, build_base_cmd_orch
+    from module_utils.ceph_common import exit_module, build_base_cmd_orch, CEPH_CLI_SHARED_OPTIONS  # type: ignore
 
 
 def parse_spec(spec: str) -> Dict:
@@ -178,6 +184,7 @@ def change_required(current: Dict, expected: Dict) -> bool:
 def run_module() -> None:
 
     module_args = dict(
+        **CEPH_CLI_SHARED_OPTIONS,
         spec=dict(type='str', required=True),
         fsid=dict(type='str', required=False),
         docker=dict(type='bool',

--- a/plugins/modules/ceph_orch_daemon.py
+++ b/plugins/modules/ceph_orch_daemon.py
@@ -60,6 +60,8 @@ options:
             - The type of the service.
         type: str
         required: true
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
 
 author:
     - Guillaume Abrioux (@guits)
@@ -83,9 +85,21 @@ RETURN = '''#  '''
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import retry, exit_module, build_base_cmd_orch, fatal  # type: ignore
+    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import (  # type: ignore
+        retry,
+        exit_module,
+        build_base_cmd_orch,
+        fatal,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 except ImportError:
-    from module_utils.ceph_common import retry, exit_module, build_base_cmd_orch, fatal  # type: ignore
+    from module_utils.ceph_common import (  # type: ignore
+        retry,
+        exit_module,
+        build_base_cmd_orch,
+        fatal,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 
 from typing import List, Tuple
 import datetime
@@ -129,6 +143,7 @@ def validate_updated_status(module: "AnsibleModule",
 def main() -> None:
     module = AnsibleModule(
         argument_spec=dict(
+            **CEPH_CLI_SHARED_OPTIONS,
             state=dict(type='str',
                        required=True,
                        choices=['started', 'stopped', 'restarted']),

--- a/plugins/modules/ceph_orch_host.py
+++ b/plugins/modules/ceph_orch_host.py
@@ -86,6 +86,9 @@ options:
         type: str
         required: false
         default: present
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
+
 author:
     - Guillaume Abrioux (@guits)
 '''
@@ -115,9 +118,13 @@ RETURN = '''#  '''
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
+    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import (  # type: ignore
+        exit_module,
+        build_base_cmd_orch,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 except ImportError:
-    from module_utils.ceph_common import exit_module, build_base_cmd_orch
+    from module_utils.ceph_common import exit_module, build_base_cmd_orch, CEPH_CLI_SHARED_OPTIONS
 
 from typing import Optional, List, Tuple
 import datetime
@@ -172,6 +179,7 @@ def update_host(module: "AnsibleModule",
 def main() -> None:
     module = AnsibleModule(
         argument_spec=dict(
+            **CEPH_CLI_SHARED_OPTIONS,
             name=dict(type='str', required=True),
             address=dict(type='str', required=False),
             set_admin_label=dict(type='bool', required=False, default=False),
@@ -199,8 +207,6 @@ def main() -> None:
 
     startd = datetime.datetime.now()
     changed = False
-
-    cmd = ['cephadm']
 
     if module.check_mode:
         exit_module(

--- a/plugins/modules/cephadm_registry_login.py
+++ b/plugins/modules/cephadm_registry_login.py
@@ -33,6 +33,8 @@ short_description: Log in to container registry
 version_added: "1.0.0"
 description:
     - Call cephadm registry-login command for logging in to container registry
+extends_documentation_fragment:
+  - ceph.automation.ceph_cli
 options:
     state:
         description:
@@ -95,9 +97,21 @@ from typing import List, Tuple
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import exit_module, build_base_cmd, fatal  # type: ignore
+    from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import (  # type: ignore
+        exit_module,
+        build_base_cmd,
+        fatal,
+        module_use_cephadm,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 except ImportError:
-    from module_utils.ceph_common import exit_module, build_base_cmd, fatal
+    from module_utils.ceph_common import (  # type: ignore
+        exit_module,
+        build_base_cmd,
+        fatal,
+        module_use_cephadm,
+        CEPH_CLI_SHARED_OPTIONS,
+    )
 
 
 def build_base_container_cmd(module: "AnsibleModule", action: str = 'login') -> List[str]:
@@ -146,6 +160,7 @@ def do_login_or_logout(module: "AnsibleModule", action: str = 'login') -> Tuple[
 def main() -> None:
     module = AnsibleModule(
         argument_spec=dict(
+            **CEPH_CLI_SHARED_OPTIONS,
             state=dict(type='str', required=False, default='login', choices=['login', 'logout']),
             docker=dict(type='bool',
                         required=False,
@@ -170,6 +185,10 @@ def main() -> None:
             ['state', 'logout', ['registry_url']]
         ]
     )
+    if not module_use_cephadm(module):
+        module.fail_json(
+            msg='cephadm_registry_login requires Cephadm. This module cannot run with use_cephadm=false.'
+        )
     startd = datetime.datetime.now()
     changed = False
     cmd = build_base_cmd(module)

--- a/tests/unit/module_utils/test_ceph_common.py
+++ b/tests/unit/module_utils/test_ceph_common.py
@@ -1,4 +1,8 @@
-from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import build_base_cmd_orch, fatal
+from ansible_collections.ceph.automation.plugins.module_utils.ceph_common import (
+    build_base_cmd_orch,
+    build_base_cmd_shell,
+    fatal,
+)
 import pytest
 from mock.mock import MagicMock
 
@@ -30,6 +34,29 @@ class TestCephCommon(object):
     def test_build_base_cmd_orch_no_arg(self):
         expected_cmd = ['cephadm', 'shell', 'ceph', 'orch']
         cmd = build_base_cmd_orch(self.fake_module)
+        assert cmd == expected_cmd
+
+    def test_build_base_cmd_orch_native_default_keyring(self):
+        self.fake_module.params = {'use_cephadm': False}
+        expected_cmd = [
+            'ceph', '-n', 'client.admin', '-k', '/etc/ceph/ceph.client.admin.keyring',
+            '--cluster', 'ceph', 'orch',
+        ]
+        cmd = build_base_cmd_orch(self.fake_module)
+        assert cmd == expected_cmd
+
+    def test_build_base_cmd_shell_native_custom_cluster(self):
+        self.fake_module.params = {
+            'use_cephadm': False,
+            'cluster': 'foo',
+            'ceph_client': 'client.admin',
+            'keyring': '/etc/ceph/custom.keyring',
+        }
+        expected_cmd = [
+            'ceph', '-n', 'client.admin', '-k', '/etc/ceph/custom.keyring',
+            '--cluster', 'foo',
+        ]
+        cmd = build_base_cmd_shell(self.fake_module)
         assert cmd == expected_cmd
 
     def test_fatal(self):


### PR DESCRIPTION
Proxmox users do not use cephadm as orchestrator. They can now disable
the usage of cephadm by setting use_cephadm in their playbooks.

AI-assisted (Cursor).