### PR TITLE
fix: cephadm_bootstrap should check /etc/ceph for idempotency

### DIFF
--- a/changelogs/fragments/cephadm_bootstrap_idempotency.yaml
+++ b/changelogs/fragments/cephadm_bootstrap_idempotency.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - cephadm_bootstrap - Corrrect the base path of ceph config from '/var/lib/ceph' to '/etc/ceph'
+    for idempotency check.

--- a/plugins/modules/cephadm_bootstrap.py
+++ b/plugins/modules/cephadm_bootstrap.py
@@ -532,6 +532,7 @@ def run_module() -> None:
 
     cmd: list[str] = []
     data_dir = '/var/lib/ceph'
+    config_dir = '/etc/ceph'
     ceph_conf = 'ceph.conf'
     ceph_keyring = 'ceph.client.admin.keyring'
     ceph_pubkey = 'ceph.pub'
@@ -564,7 +565,7 @@ def run_module() -> None:
               ceph_keyring,
               ceph_pubkey]:
         if not allow_overwrite:
-            path: str = os.path.join(data_dir, f)
+            path: str = os.path.join(config_dir, f)
             if os.path.exists(path):
                 out = f'{path} already exists, skipping.'
                 exit_module(

--- a/tests/unit/modules/test_cephadm_bootstrap.py
+++ b/tests/unit/modules/test_cephadm_bootstrap.py
@@ -303,3 +303,41 @@ class TestCephadmBootstrapModule(object):
         assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip,
                                  '--registry-json', fake_registry_json]
         assert result['rc'] == 0
+
+    @patch('os.path.exists')
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_idempotent_when_default_ceph_conf_exists(self, m_run_command, m_exit_json, m_exists):
+        set_module_args({
+            'mon_ip': fake_ip
+        })
+        m_exit_json.side_effect = exit_json
+        m_exists.side_effect = lambda p: p == '/etc/ceph/ceph.conf'
+
+        with pytest.raises(AnsibleExitJson) as result:
+            main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['rc'] == 0
+        assert '/etc/ceph/ceph.conf already exists' in result['stdout']
+        m_run_command.assert_not_called()
+
+    @patch('os.path.exists')
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_idempotent_skipped_when_allow_overwrite(self, m_run_command, m_exit_json, m_exists):
+        set_module_args({
+            'mon_ip': fake_ip,
+            'allow_overwrite': True
+        })
+        m_exit_json.side_effect = exit_json
+        m_exists.return_value = True
+        m_run_command.return_value = 0, '', ''
+
+        with pytest.raises(AnsibleExitJson) as result:
+            main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--allow-overwrite', '--mon-ip', fake_ip]


### PR DESCRIPTION
Module cephadm_bootstrap should check if Ceph config already exists for idempotency check.
The module has been checking '/var/lib/ceph', while the default config dir is '/etc/ceph'.
The bug introduced from upstream: https://github.com/ceph/cephadm-ansible/commit/2645b6ad95be2ed787a51d43739deb8a7e098143